### PR TITLE
 Fix don't use render targets as textures warning

### DIFF
--- a/lib/shaderpass.js
+++ b/lib/shaderpass.js
@@ -32,7 +32,7 @@ module.exports = function(THREE, EffectComposer) {
 
       if ( this.uniforms[ this.textureID ] ) {
 
-        this.uniforms[ this.textureID ].value = readBuffer;
+        this.uniforms[ this.textureID ].value = readBuffer.texture;
 
       }
 


### PR DESCRIPTION
In the shaderpass file I added .texture to the end of readBuffer to fix this warning.
