### PR TITLE
fixed render target issue for three^0.102.1

### DIFF
--- a/lib/shaderpass.js
+++ b/lib/shaderpass.js
@@ -32,7 +32,7 @@ module.exports = function(THREE, EffectComposer) {
 
       if ( this.uniforms[ this.textureID ] ) {
 
-        this.uniforms[ this.textureID ].value = readBuffer;
+        this.uniforms[ this.textureID ].value = readBuffer.texture;
 
       }
 
@@ -44,7 +44,11 @@ module.exports = function(THREE, EffectComposer) {
 
       } else {
 
-        renderer.render( EffectComposer.scene, EffectComposer.camera, writeBuffer, this.clear );
+        renderer.setRenderTarget( writeBuffer );
+        if ( this.clear )
+            renderer.clear();
+
+        renderer.render( EffectComposer.scene, EffectComposer.camera );
 
       }
 


### PR DESCRIPTION
Three.js new version has discarded render target parameter in method [WebGLRenderer.render](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.render).

Also fixed texture shader uniform value issue to avoid warning inside three.js.